### PR TITLE
Make mongoid a soft dependency.

### DIFF
--- a/lib/duration.rb
+++ b/lib/duration.rb
@@ -9,6 +9,8 @@ require 'active_support/core_ext'
 # be useful for those scripts or applications that allow you to know the uptime
 # of themselves or perhaps provide a countdown until a certain event.
 class Duration
+  autoload :Dependency, 'duration/dependency'
+
   include Comparable
 
   UNITS = [:seconds, :minutes, :hours, :days, :weeks]

--- a/lib/duration/dependency.rb
+++ b/lib/duration/dependency.rb
@@ -1,0 +1,23 @@
+class Duration
+  class Dependency
+    LIBS = {
+      'mongoid' => { :require => 'mongoid', :version => '~> 2.4.0' },
+    }
+
+    def self.load(name)
+      begin
+        gem(name, LIBS[name][:version])
+        require(LIBS[name][:require])
+      rescue LoadError
+        abort <<-EOS
+Dependency missing: #{name}
+To install the gem, issue the following command:
+
+    gem install #{name} -v '#{LIBS[name][:version]}'
+
+Please try again after installing the missing dependency.
+        EOS
+      end
+    end
+  end
+end

--- a/lib/duration/mongoid.rb
+++ b/lib/duration/mongoid.rb
@@ -1,5 +1,6 @@
-require "#{File.dirname(__FILE__)}/../duration"
-require "mongoid/fields"
+require 'duration'
+Duration::Dependency.load('mongoid')
+require 'mongoid/fields'
 
 # Mongoid serialization support for Duration type.
 module Mongoid

--- a/ruby-duration.gemspec
+++ b/ruby-duration.gemspec
@@ -23,8 +23,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake", ">= 0"
   s.add_development_dependency "simplecov", ">= 0.3.5"
   s.add_development_dependency "bluecloth", ">= 0.3.5"
-  
-  s.add_runtime_dependency "mongoid", "~> 2.4.0"
 
   s.files        = `git ls-files`.split("\n")
   s.executables  = `git ls-files`.split("\n").map{|f| f =~ /^bin\/(.*)/ ? $1 : nil}.compact


### PR DESCRIPTION
I use `mongoid` in some projects, and I like it a lot, but when I don't, it's too huge as a runtime dependency.

Also you don't need `require "#{File.dirname(__FILE__)}/duration"` as explained here:

http://guides.rubygems.org/patterns/#loading-code

```
Gems should not have to use __FILE__ to bring in other Ruby files in your gem.
```
