### PR TITLE
Changed from gemcutter to https://rubygems.org

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :gemcutter
+source 'https://rubygems.org'
 
 # Specify your gem's dependencies in ruby-duration.gemspec
 gemspec


### PR DESCRIPTION
Getting the deprecation warning:
`The source :gemcutter is deprecated because HTTP requests are insecure.`
when running `bundle install`
