### PR TITLE
Fix minitest warning

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -12,4 +12,4 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 require 'ruby-duration'
 
-MiniTest::Unit.autorun
+MiniTest.autorun


### PR DESCRIPTION
- MiniTest::Unit.autorun is now Minitest.autorun
- Warning: you should require 'minitest/autorun' instead.
