### PR TITLE
Add ability to parse iso8601 durations.

### DIFF
--- a/lib/duration.rb
+++ b/lib/duration.rb
@@ -1,6 +1,7 @@
 # -*- encoding:  utf-8 -*-
 require 'i18n'
 require 'active_support/core_ext'
+require 'iso8601'
 
 # Duration objects are simple mechanisms that allow you to operate on durations
 # of time.  They allow you to know how much time has passed since a certain
@@ -39,11 +40,21 @@ class Duration
         unit = unit.to_sym
         @seconds += args[unit].to_i * multiple if args.key?(unit)
       end
+    elsif args.kind_of?(String) and args[0] == 'P'
+      @seconds = ISO8601::Duration.new(args).to_seconds
     else
       @seconds = args.to_i
     end
 
     calculate!
+  end
+
+  def self.load string
+    self.new(string)
+  end
+
+  def self.dump duration
+    duration.iso8601
   end
 
   # Compare this duration to another (or objects that respond to #to_i)
@@ -81,8 +92,8 @@ class Duration
   def iso8601
     output = 'P'
 
-    output << "#{weeks}W" if weeks > 0
-    output << "#{days}D" if days > 0
+    number_of_days = weeks * 7 + days
+    output << "#{number_of_days}D" if number_of_days > 0
     if seconds > 0 || minutes > 0 || hours > 0
       output << 'T'
       output << "#{hours}H" if hours > 0

--- a/ruby-duration.gemspec
+++ b/ruby-duration.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "activesupport", ">= 3.0.0"
   s.add_dependency "i18n", ">= 0"
+  s.add_dependency "iso8601", ">= 0"
 
   s.add_development_dependency "bundler", ">= 1.0.0"
   s.add_development_dependency "minitest", ">= 0"

--- a/test/test_duration.rb
+++ b/test/test_duration.rb
@@ -28,6 +28,12 @@ describe "Duration" do
     assert_equal      9, d.total_days
   end
 
+  it 'should load and dump' do
+    duration = Duration.new(:seconds => 3)
+    assert_equal 'PT3S', Duration.dump(duration)
+    assert_equal Duration.load('PT3S'), duration
+  end
+
   describe "mathematical operations" do
 
     it "should +" do
@@ -123,6 +129,16 @@ describe "Duration" do
     end
   end
 
+  describe "creation from iso_8601" do
+    it "should work" do
+      assert_equal 60, Duration.new("PT1M").to_i
+      assert_equal 3630, Duration.new("PT1H30S").to_i
+
+      duration = Duration.new(:weeks => 1, :days => 1, :hours => 2, :minutes => 1, :seconds => 2)
+      assert_equal duration, Duration.new(duration.iso8601)
+    end
+  end
+
   describe "#iso_6801" do
     it "should format seconds" do
       d = Duration.new(:seconds => 1)
@@ -144,20 +160,20 @@ describe "Duration" do
       assert_equal "P1D", d.iso8601
     end
 
-    it "should format weeks" do
+    it "should format weeks as ndays" do
       d = Duration.new(:weeks => 1)
-      assert_equal "P1W", d.iso8601
+      assert_equal "P7D", d.iso8601
     end
 
     it "should format only with given values" do
       d = Duration.new(:weeks => 1, :days => 2, :hours => 3, :minutes => 4, :seconds => 5)
-      assert_equal "P1W2DT3H4M5S", d.iso8601
+      assert_equal "P9DT3H4M5S", d.iso8601
 
       d = Duration.new(:weeks => 1, :hours => 2, :seconds => 3)
-      assert_equal "P1WT2H3S", d.iso8601
+      assert_equal "P7DT2H3S", d.iso8601
 
       d = Duration.new(:weeks => 1, :days => 2)
-      assert_equal "P1W2D", d.iso8601
+      assert_equal "P9D", d.iso8601
 
       d = Duration.new(:hours => 1, :seconds => 30)
       assert_equal "PT1H30S", d.iso8601


### PR DESCRIPTION
I'm not an ISO8601 expert, but it appears many implementations ignore
weeks in the format string. The Ruby iso8601 library does, and
postgresql does as well:

```
select interval '1w';
P7D
```

In order to better operate with those libraries, ruby-duration no longer
includes the week in the iso8601 format.
