### PR TITLE
activesupport 4.2.0 breaks your gem

### DIFF
--- a/ruby-duration.gemspec
+++ b/ruby-duration.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "ruby-duration"
 
-  s.add_dependency "activesupport", ">= 3.0.0"
+  s.add_dependency "activesupport", ">= 3.0.0", "< 4.2.0"
   s.add_dependency "i18n", ">= 0"
   s.add_dependency "iso8601", ">= 0"
 


### PR DESCRIPTION
Got: `An error occurred: uninitialized constant ActiveSupport::Deprecation` with 4.2.0, looks like they took something out you were using.