### PR TITLE
Readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ For lower Mongoid versions try:
  * < 3.0.0 tag [v2.1.4](https://github.com/peleteiro/ruby-duration/tree/v2.1.4)
  * < 2.1.0 tag [v1.0.0](https://github.com/peleteiro/ruby-duration/tree/v1.0.0)
 
+```
     require 'duration/mongoid'
 
-```
     class MyModel
       include Mongoid::Document
       field :duration, type => Duration

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ ruby-duration
 
 Duration is an immutable type that represents some amount of time with accuracy in seconds.
 
-A lot of the code and inspirations is borrowed from [duration](http://rubyforge.org/projects/duration) 
+A lot of the code and inspirations is borrowed from [duration](http://rubyforge.org/projects/duration)
 lib, which is a **mutable** Duration type with lot more features.
 
 
@@ -43,13 +43,15 @@ For lower Mongoid versions try:
 
     require 'duration/mongoid'
 
+```
     class MyModel
       include Mongoid::Document
       field :duration, type => Duration
     end
+```
 
 ### Dependencies
-The current version of this gem runs only on Ruby Versions >= 1.9.3. 
+The current version of this gem runs only on Ruby Versions >= 1.9.3.
 If you are running a older version of Ruby try:
 * tag [v2.1.4](https://github.com/peleteiro/ruby-duration/tree/v2.1.4)
 


### PR DESCRIPTION
Corrected a small typo--a code block in the README that wasn't formatted as a code block and removed some random whitespace.