### PR TITLE
active_support/core_ext breaks JSON output, is it really needed?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+before_install: gem install bundler
 rvm:
   - 1.9.3
   - 2.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: ruby
 before_install: gem install bundler
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: ruby
 before_install: gem install bundler
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1
   - 2.2
-  - jruby-19mode
+matrix:
+  include:
+    - rvm: 1.9.3
+      gemfile: Gemfile.ruby-1.9.rb
+    - rvm: jruby-19mode
+      gemfile: Gemfile.ruby-1.9.rb

--- a/Gemfile.ruby-1.9.rb
+++ b/Gemfile.ruby-1.9.rb
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in ruby-duration.gemspec
+gemspec
+
+# iso8601 >= 0.9.0 requires Ruby >= 2.0.0.
+gem 'iso8601', '~> 0.8.7'

--- a/lib/duration.rb
+++ b/lib/duration.rb
@@ -1,7 +1,5 @@
 # -*- encoding:  utf-8 -*-
 require 'i18n'
-require 'active_support'
-require 'active_support/core_ext'
 require 'iso8601'
 
 # Duration objects are simple mechanisms that allow you to operate on durations

--- a/lib/duration/mongoid.rb
+++ b/lib/duration/mongoid.rb
@@ -1,4 +1,5 @@
 require "#{File.dirname(__FILE__)}/../duration"
+require "mongoid"
 require "mongoid/fields"
 
 # Mongoid serialization support for Duration type.

--- a/ruby-duration.gemspec
+++ b/ruby-duration.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "ruby-duration"
 
-  s.add_dependency "activesupport", ">= 3.0.0"
   s.add_dependency "i18n", ">= 0"
   s.add_dependency "iso8601", ">= 0"
 


### PR DESCRIPTION
If `duration` is required in any of our projects it changes our JSON time formats, breaking our API. This is because of ActiveSupport::CoreExtensions:

http://api.rubyonrails.org/files/activesupport/lib/active_support/core_ext/object/json_rb.html

This is pretty bad behavior in my opinion. Are active_support/core_ext's really needed? I don't think it's a good idea for libraries to use them.