### PR TITLE
gemspec: Drop EOL'd property rubyforge_project

### DIFF
--- a/ruby-duration.gemspec
+++ b/ruby-duration.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
   s.description = "Duration type"
 
   s.required_rubygems_version = ">= 1.3.6"
-  s.rubyforge_project         = "ruby-duration"
 
 
   s.add_dependency "activesupport", ">= 3.0.0"


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

* [RubyForge was closed down in 2013][1].
* [rubygems/rubygems#2436 deprecated the `rubyforge_project` property][2].

[1]: https://twitter.com/evanphx/status/399552820380053505
[2]: rubygems/rubygems#2436